### PR TITLE
Supports Laravel 12

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,9 @@
 # Type Safe Env
 
+> [!NOTE]
+> This is a fork of the `kero/typesafe-env` package. It adds:
+> - Support for Laravel 12
+
 Install via `composer req kero/typesafe-env`
 
 ![GitHub latest tag](https://img.shields.io/github/v/tag/kingkero/typesafe-env) [![codecov](https://codecov.io/gh/kingkero/typesafe-env/graph/badge.svg?token=4EAAZYEAN3)](https://codecov.io/gh/kingkero/typesafe-env) ![license: MIT](https://img.shields.io/github/license/kingkero/typesafe-env)

--- a/composer.json
+++ b/composer.json
@@ -3,7 +3,6 @@
     "description": "Wrapper around Laravel's Env to support type safety.",
     "license": "MIT",
     "type": "library",
-    "version": "0.1.2",
     "authors": [
         {
             "name": "Martin Rehberger",

--- a/composer.json
+++ b/composer.json
@@ -16,7 +16,7 @@
     },
     "require": {
         "php": "^8.1",
-        "illuminate/support": "^10.0 || ^11.0",
+        "illuminate/support": "^10.0 || ^11.0 || ^12.0",
         "phpoption/phpoption": "^1.9",
         "vlucas/phpdotenv": "^5.5"
     },

--- a/phpstan.neon
+++ b/phpstan.neon
@@ -2,4 +2,4 @@ parameters:
     paths:
         - src/
         - tests/
-    level: 9
+    level: max


### PR DESCRIPTION
This pull request includes a small change to the `composer.json` file. The change updates the version constraints for the `illuminate/support` package to include support for version 12.0.

* [`composer.json`](diffhunk://#diff-d2ab9925cad7eac58e0ff4cc0d251a937ecf49e4b6bf57f8b95aab76648a9d34L19-R19): Updated the version constraints for the `illuminate/support` package to "^10.0 || ^11.0 || ^12.0".